### PR TITLE
Update validation rule for 'amount' field in QRStaticPaymentCreate

### DIFF
--- a/src/Rules/PIX/QRStaticPaymentCreate.php
+++ b/src/Rules/PIX/QRStaticPaymentCreate.php
@@ -10,7 +10,7 @@ class QRStaticPaymentCreate
     public static function rules(): array
     {
         return [
-            'amount' => ['required', 'regex:/\d{1,10}\.\d{2}/'],
+            'amount' => ['required', 'decimal:0,2'],
             'key' => ['required', 'string'],
             'transactionIdentification' => ['required', 'string'],
             'additionalInformation' => ['sometimes', 'string'],


### PR DESCRIPTION
Updated the validation rule of the 'amount' field in the QRStaticPaymentCreate ruleset from a regular expression to a simpler 'decimal' validation. This change will improve readability and maintainability of the code while still maintaining the intended restriction, which is to allow only decimal numbers with utmost two decimal places.