### PR TITLE
Update validation rule for 'keyType' in RegisterPixKey

### DIFF
--- a/src/Rules/BAAS/RegisterPixKey.php
+++ b/src/Rules/BAAS/RegisterPixKey.php
@@ -12,7 +12,7 @@ class RegisterPixKey extends Data
     {
         return [
             "account" => ['required', 'string'],
-            "keyType" => ['required', Rule::in([PixKeyTypeEnum::EVP->value])],
+            "keyType" => ['required', Rule::enum(PixKeyTypeEnum::class)],
             "key" => ['required_unless:keyType,EVP', 'string'],
         ];
     }


### PR DESCRIPTION
This change updates the validation rule for the 'keyType' parameter in the RegisterPixKey class. Previously, only EVP keys were allowed. Now, any key enumerated in the PixKeyTypeEnum class can be used. This provides greater flexibility for different types of Pix keys.

Reopen from #14 'cause Github Actions didn't run