### PR TITLE
Update endpoint paths and adjust optional parameters in CelcoinBAASPIX

### DIFF
--- a/src/Clients/CelcoinBAASPIX.php
+++ b/src/Clients/CelcoinBAASPIX.php
@@ -20,12 +20,12 @@ class CelcoinBAASPIX extends CelcoinBaseApi
 {
 
     const CASH_OUT_ENDPOINT = '/baas-wallet-transactions-webservice/v1/pix/payment';
-    const GET_PARTICIPANT_ENDPOINT = '/celcoin-baas-wallet-transactions-webservice/v1/pix/participant';
+    const GET_PARTICIPANT_ENDPOINT = '/baas-wallet-transactions-webservice/v1/pix/participant';
     const GET_EXTERNAL_KEY_ENDPOINT = '/celcoin-baas-pix-dict-webservice/v1/pix/dict/entry/external/%s';
     const STATUS_PIX_ENDPOINT = '/baas-wallet-transactions-webservice/v1/pix/payment/status';
-    const REGISTER_PIX_KEY_ENDPOINT = '/celcoin-baas-pix-dict-webservice/v1/pix/dict/entry';
-    const SEARCH_PIX_KEY_ENDPOINT = '/celcoin-baas-pix-dict-webservice/v1/pix/dict/entry/%s';
-    const DELETE_PIX_KEY_ENDPOINT = '/celcoin-baas-pix-dict-webservice/v1/pix/dict/entry/%s';
+    const REGISTER_PIX_KEY_ENDPOINT = '/baas-pix-dict-webservice/v1/pix/dict/entry';
+    const SEARCH_PIX_KEY_ENDPOINT = '/baas-pix-dict-webservice/v1/pix/dict/entry/%s';
+    const DELETE_PIX_KEY_ENDPOINT = '/baas-pix-dict-webservice/v1/pix/dict/entry/%s';
     const REFUND_PIX_ENDPOINT = '/baas-wallet-transactions-webservice/v1/pix/reverse';
     const STATUS_REFUND_PIX_ENDPOINT = '/baas-wallet-transactions-webservice/v1/pix/reverse/status';
 
@@ -38,7 +38,7 @@ class CelcoinBAASPIX extends CelcoinBaseApi
         );
     }
 
-    public function getParticipant(?string $ISPB, ?string $name)
+    public function getParticipant(?string $ISPB = null, ?string $name = null)
     {
         return $this->get(
             self::GET_PARTICIPANT_ENDPOINT,

--- a/src/Clients/CelcoinBAASPIX.php
+++ b/src/Clients/CelcoinBAASPIX.php
@@ -23,9 +23,9 @@ class CelcoinBAASPIX extends CelcoinBaseApi
     const GET_PARTICIPANT_ENDPOINT = '/baas-wallet-transactions-webservice/v1/pix/participant';
     const GET_EXTERNAL_KEY_ENDPOINT = '/celcoin-baas-pix-dict-webservice/v1/pix/dict/entry/external/%s';
     const STATUS_PIX_ENDPOINT = '/baas-wallet-transactions-webservice/v1/pix/payment/status';
-    const REGISTER_PIX_KEY_ENDPOINT = '/baas-pix-dict-webservice/v1/pix/dict/entry';
-    const SEARCH_PIX_KEY_ENDPOINT = '/baas-pix-dict-webservice/v1/pix/dict/entry/%s';
-    const DELETE_PIX_KEY_ENDPOINT = '/baas-pix-dict-webservice/v1/pix/dict/entry/%s';
+    const REGISTER_PIX_KEY_ENDPOINT = '/celcoin-baas-pix-dict-webservice/v1/pix/dict/entry';
+    const SEARCH_PIX_KEY_ENDPOINT = '/celcoin-baas-pix-dict-webservice/v1/pix/dict/entry/%s';
+    const DELETE_PIX_KEY_ENDPOINT = '/celcoin-baas-pix-dict-webservice/v1/pix/dict/entry/%s';
     const REFUND_PIX_ENDPOINT = '/baas-wallet-transactions-webservice/v1/pix/reverse';
     const STATUS_REFUND_PIX_ENDPOINT = '/baas-wallet-transactions-webservice/v1/pix/reverse/status';
 


### PR DESCRIPTION
Adjusted the endpoint paths in CelcoinBAASPIX to match the current service URLs, removing the 'celcoin-' prefix. Additionally, the getParticipant method has been updated to give both parameters a default null value, improving the method's flexibility in case of missing information. These changes will streamline the code's functioning and communication with the backend services.